### PR TITLE
Concurrency: Add CompletionStage in exception handling

### DIFF
--- a/concurrency/src/main/java/io/mincong/concurrency/completablefuture/ExceptionHandlingDemo.java
+++ b/concurrency/src/main/java/io/mincong/concurrency/completablefuture/ExceptionHandlingDemo.java
@@ -2,6 +2,7 @@ package io.mincong.concurrency.completablefuture;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Demonstrate the exception handling mechanism in Java Completable Future.
@@ -9,14 +10,23 @@ import java.util.concurrent.CompletionException;
  * <p>Example output:
  *
  * <pre>
- * ----- handle -----
+ * ----- handle (CompletableFuture) -----
  * Recovered from "Oops"
- * ----- whenComplete -----
+ * ----- handle (CompletionStage) -----
+ * Recovered from "Oops"
+ * ----- whenComplete (CompletableFuture) -----
  * Exception occurred
  * Error: java.lang.RuntimeException: Oops
- * ----- exceptionally (with exception) -----
+ * ----- whenComplete (CompletionStage) -----
+ * Exception occurred
+ * Error: java.lang.RuntimeException: Oops
+ * ----- exceptionally with exception (CompletableFuture) -----
  * Recovered from "Oops"
- * ----- exceptionally (without exception) -----
+ * ----- exceptionally without exception (CompletableFuture) -----
+ * OK
+ * ----- exceptionally with exception (CompletionStage) -----
+ * Recovered from "Oops"
+ * ----- exceptionally without exception (CompletionStage) -----
  * OK
  * ----- End -----
  * </pre>
@@ -27,7 +37,7 @@ public class ExceptionHandlingDemo {
 
   public static void main(String[] args) {
     /*
-     * Case 1: handle(BiFunction<? super T, Throwable, ? extends U> fn): CompletableFuture<U>
+     * Case 1: handle(BiFunction<? super T, Throwable, ? extends U> fn): { CompletableFuture<U>, CompletionStage<U> }
      *
      * - Has access to success? Yes
      * - Has access to failure? Yes
@@ -35,10 +45,11 @@ public class ExceptionHandlingDemo {
      * - Is triggered when stage succeed? Yes
      * - Is triggered when stage failed? Yes
      */
-    handle();
+    handleCF();
+    handleCS();
 
     /*
-     * Case 2: whenComplete(BiConsumer<? super T, ? super Throwable> action): CompletableFuture<T>
+     * Case 2: whenComplete(BiConsumer<? super T, ? super Throwable> action): { CompletableFuture<T>, CompletionStage<T> }
      *
      * - Has access to success? Yes
      * - Has access to failure? Yes
@@ -47,7 +58,16 @@ public class ExceptionHandlingDemo {
      * - Is triggered when stage failed? Yes
      */
     try {
-      whenComplete();
+      whenCompleteCF();
+    } catch (CompletionException e) {
+      /*
+       * Previous failure "Oops" is encapsulated by as `CompletionException`
+       * and is thrown when `join()` happens.
+       */
+      System.out.println("Error: " + e.getMessage());
+    }
+    try {
+      whenCompleteCS();
     } catch (CompletionException e) {
       /*
        * Previous failure "Oops" is encapsulated by as `CompletionException`
@@ -57,7 +77,7 @@ public class ExceptionHandlingDemo {
     }
 
     /*
-     * Case 3: exceptionally(Function<Throwable, ? extends T> fn): CompletableFuture<T>
+     * Case 3: exceptionally(Function<Throwable, ? extends T> fn): { CompletableFuture<T>, CompletionStage<T> }
      *
      * - Has access to success? No
      * - Has access to failure? Yes
@@ -65,14 +85,16 @@ public class ExceptionHandlingDemo {
      * - Is triggered when stage succeed? No
      * - Is triggered when stage failed? Yes
      */
-    exceptionally1();
-    exceptionally2();
+    exceptionallyCF1();
+    exceptionallyCF2();
+    exceptionallyCS1();
+    exceptionallyCS2();
 
     System.out.println("----- End -----");
   }
 
-  private static void handle() {
-    System.out.println("----- handle -----");
+  private static void handleCF() {
+    System.out.println("----- handle (CompletableFuture) -----");
     CompletableFuture<String> cf =
         CompletableFuture.<String>failedFuture(new RuntimeException("Oops"))
             .handle(
@@ -86,8 +108,23 @@ public class ExceptionHandlingDemo {
     System.out.println(cf.join());
   }
 
-  private static void whenComplete() {
-    System.out.println("----- whenComplete -----");
+  private static void handleCS() {
+    System.out.println("----- handle (CompletionStage) -----");
+    CompletionStage<String> cs =
+        CompletableFuture.<String>failedStage(new RuntimeException("Oops"))
+            .handle(
+                (msg, ex) -> {
+                  if (ex != null) {
+                    return "Recovered from \"" + ex.getMessage() + "\"";
+                  } else {
+                    return msg;
+                  }
+                });
+    System.out.println(cs.toCompletableFuture().join());
+  }
+
+  private static void whenCompleteCF() {
+    System.out.println("----- whenComplete (CompletableFuture) -----");
     CompletableFuture<String> cf =
         CompletableFuture.<String>failedFuture(new RuntimeException("Oops"))
             /*
@@ -96,6 +133,7 @@ public class ExceptionHandlingDemo {
              * However, you cannot modify the result of the stage by returning
              * a new value.
              */
+            // whenComplete(BiConsumer<? super T, ? super Throwable> action): CompletableFuture<T>
             .whenComplete(
                 (msg, ex) -> {
                   if (ex != null) {
@@ -103,21 +141,41 @@ public class ExceptionHandlingDemo {
                   } else {
                     System.out.println(msg);
                   }
-                  // cannot return value
+                  /*
+                   * Cannot return value because method whenComplete
+                   * uses bi-consumer as input parameter:
+                   * BiConsumer<? super T, ? super Throwable> action
+                   */
                 });
     System.out.println(cf.join());
   }
 
-  private static void exceptionally1() {
-    System.out.println("----- exceptionally (with exception) -----");
+  private static void whenCompleteCS() {
+    System.out.println("----- whenComplete (CompletionStage) -----");
+    CompletionStage<String> cs =
+        CompletableFuture.<String>failedStage(new RuntimeException("Oops"))
+            // whenComplete(BiConsumer<? super T, ? super Throwable> action): CompletionStage<T>
+            .whenComplete(
+                (msg, ex) -> {
+                  if (ex != null) {
+                    System.out.println("Exception occurred");
+                  } else {
+                    System.out.println(msg);
+                  }
+                });
+    System.out.println(cs.toCompletableFuture().join());
+  }
+
+  private static void exceptionallyCF1() {
+    System.out.println("----- exceptionally with exception (CompletableFuture) -----");
     CompletableFuture<String> cf =
         CompletableFuture.<String>failedFuture(new RuntimeException("Oops"))
             .exceptionally(ex -> "Recovered from \"" + ex.getMessage() + "\"");
     System.out.println(cf.join());
   }
 
-  private static void exceptionally2() {
-    System.out.println("----- exceptionally (without exception) -----");
+  private static void exceptionallyCF2() {
+    System.out.println("----- exceptionally without exception (CompletableFuture) -----");
     CompletableFuture<String> cf =
         CompletableFuture.completedFuture("OK")
             .exceptionally(
@@ -130,5 +188,25 @@ public class ExceptionHandlingDemo {
                   return "Recovered from \"" + ex.getMessage() + "\"";
                 });
     System.out.println(cf.join());
+  }
+
+  private static void exceptionallyCS1() {
+    System.out.println("----- exceptionally with exception (CompletionStage) -----");
+    CompletionStage<String> cs =
+        CompletableFuture.<String>failedStage(new RuntimeException("Oops"))
+            .exceptionally(ex -> "Recovered from \"" + ex.getMessage() + "\"");
+    System.out.println(cs.toCompletableFuture().join());
+  }
+
+  private static void exceptionallyCS2() {
+    System.out.println("----- exceptionally without exception (CompletionStage) -----");
+    CompletionStage<String> cf =
+        CompletableFuture.completedStage("OK")
+            .exceptionally(
+                ex -> {
+                  System.out.println("Handling exception");
+                  return "Recovered from \"" + ex.getMessage() + "\"";
+                });
+    System.out.println(cf.toCompletableFuture().join());
   }
 }

--- a/concurrency/src/main/java/io/mincong/concurrency/completablefuture/ExceptionHandlingDemo.java
+++ b/concurrency/src/main/java/io/mincong/concurrency/completablefuture/ExceptionHandlingDemo.java
@@ -27,7 +27,7 @@ public class ExceptionHandlingDemo {
 
   public static void main(String[] args) {
     /*
-     * Case 1: handle(BiFunction<? super T, Throwable, ? extends U> fn)
+     * Case 1: handle(BiFunction<? super T, Throwable, ? extends U> fn): CompletableFuture<U>
      *
      * - Has access to success? Yes
      * - Has access to failure? Yes
@@ -38,7 +38,7 @@ public class ExceptionHandlingDemo {
     handle();
 
     /*
-     * Case 2: whenComplete(BiConsumer<? super T, ? super Throwable> action)
+     * Case 2: whenComplete(BiConsumer<? super T, ? super Throwable> action): CompletableFuture<T>
      *
      * - Has access to success? Yes
      * - Has access to failure? Yes
@@ -57,7 +57,7 @@ public class ExceptionHandlingDemo {
     }
 
     /*
-     * Case 3: exceptionally(Function<Throwable, ? extends T> fn)
+     * Case 3: exceptionally(Function<Throwable, ? extends T> fn): CompletableFuture<T>
      *
      * - Has access to success? No
      * - Has access to failure? Yes


### PR DESCRIPTION
Both `CompletionStage` and `CompletableFuture` have methods `handle`, `whenComplete`, and `exceptionally` for exception handling. So it makes sense to add `CompletionStage`.