### PR TITLE
Move dependencies to child modules

### DIFF
--- a/jetty/pom.xml
+++ b/jetty/pom.xml
@@ -12,15 +12,21 @@
   <artifactId>java-examples-jetty</artifactId>
   <name>Java Examples - Jetty</name>
 
+  <properties>
+    <jetty.version>9.4.30.v20200611</jetty.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/jgit-http/pom.xml
+++ b/jgit-http/pom.xml
@@ -13,6 +13,10 @@
   <artifactId>java-examples-jgit-http</artifactId>
   <name>Java Examples - JGit HTTP</name>
 
+  <properties>
+    <jetty.version>9.4.30.v20200611</jetty.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
@@ -35,10 +39,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/jgit-http/pom.xml
+++ b/jgit-http/pom.xml
@@ -15,16 +15,19 @@
 
   <properties>
     <jetty.version>9.4.30.v20200611</jetty.version>
+    <jgit.version>5.8.0.202006091008-r</jgit.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
+      <version>${jgit.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit.http.server</artifactId>
+      <version>${jgit.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jgit/pom.xml
+++ b/jgit/pom.xml
@@ -13,10 +13,15 @@
   <artifactId>java-examples-jgit</artifactId>
   <name>Java Examples - JGit</name>
 
+  <properties>
+    <jgit.version>5.8.0.202006091008-r</jgit.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
+      <version>${jgit.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,6 @@
     <myFacesVersion>2.2.11</myFacesVersion>
     <slf4jVersion>1.7.30</slf4jVersion>
     <vavrVersion>1.0.0-alpha-3</vavrVersion>
-    <xercesVersion>2.12.0</xercesVersion>
-    <xstreamVersion>1.4.12</xstreamVersion>
   </properties>
 
   <modules>
@@ -133,11 +131,6 @@
         <groupId>org.eclipse.jgit</groupId>
         <artifactId>org.eclipse.jgit.http.server</artifactId>
         <version>${jgitVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>${xstreamVersion}</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -271,11 +264,6 @@
         <groupId>io.vavr</groupId>
         <artifactId>vavr</artifactId>
         <version>${vavrVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>${xercesVersion}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
     <mockitoVersion>1.10.19</mockitoVersion>
     <myFacesVersion>2.2.11</myFacesVersion>
     <slf4jVersion>1.7.30</slf4jVersion>
-    <vavrVersion>1.0.0-alpha-3</vavrVersion>
   </properties>
 
   <modules>
@@ -259,11 +258,6 @@
         <groupId>javax.validation</groupId>
         <artifactId>validation-api</artifactId>
         <version>${javaxValidationVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vavr</groupId>
-        <artifactId>vavr</artifactId>
-        <version>${vavrVersion}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     <jaxbVersion>2.2.11</jaxbVersion>
     <jaxrsVersion>2.1</jaxrsVersion>
     <jerseyVersion>2.31</jerseyVersion>
-    <jettyVersion>9.4.30.v20200611</jettyVersion>
     <jgitVersion>5.8.0.202006091008-r</jgitVersion>
     <jsonVersion>20160810</jsonVersion>
     <jsonUnitVersion>2.18.1</jsonUnitVersion>
@@ -267,16 +266,6 @@
         <groupId>javax.validation</groupId>
         <artifactId>validation-api</artifactId>
         <version>${javaxValidationVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>${jettyVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
-        <version>${jettyVersion}</version>
       </dependency>
       <dependency>
         <groupId>io.vavr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     <jaxbVersion>2.2.11</jaxbVersion>
     <jaxrsVersion>2.1</jaxrsVersion>
     <jerseyVersion>2.31</jerseyVersion>
-    <jgitVersion>5.8.0.202006091008-r</jgitVersion>
     <jsonVersion>20160810</jsonVersion>
     <jsonUnitVersion>2.18.1</jsonUnitVersion>
     <junitVersion>4.13</junitVersion>
@@ -120,16 +119,6 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commonsIoVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jgit</groupId>
-        <artifactId>org.eclipse.jgit</artifactId>
-        <version>${jgitVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jgit</groupId>
-        <artifactId>org.eclipse.jgit.http.server</artifactId>
-        <version>${jgitVersion}</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -13,10 +13,15 @@
   <artifactId>java-examples-vavr</artifactId>
   <name>Java Examples - VAVR</name>
 
+  <properties>
+    <vavr.version>1.0.0-alpha-3</vavr.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.vavr</groupId>
       <artifactId>vavr</artifactId>
+      <version>${vavr.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -13,6 +13,11 @@
   <artifactId>java-examples-xml</artifactId>
   <name>Java Examples - XML</name>
 
+  <properties>
+    <xerces.version>2.12.0</xerces.version>
+    <xstream.version>1.4.12</xstream.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -21,10 +26,12 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
+      <version>${xstream.version}</version>
     </dependency>
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
+      <version>${xerces.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Because each Maven module is a set of demos for one target framework / technology. Centralizing all the dependencies in the parent POM may cause problems the build the whole project in the future.